### PR TITLE
Feature/hardcode cleanup

### DIFF
--- a/votefinder/main/SAForumPageDownloader.py
+++ b/votefinder/main/SAForumPageDownloader.py
@@ -4,7 +4,6 @@ import requests
 
 from bs4 import BeautifulSoup
 from django.conf import settings
-from votefinder.main.models import Game
 
 
 class SAForumPageDownloader():
@@ -28,14 +27,9 @@ class SAForumPageDownloader():
             return None
         return None
 
-    def log_login_attempt(self):
-        game = Game.objects.get(id=228)
-        game.status_update('Trying to re-login to forums.  PM Alli if this happens a lot.')
-
     def login_to_forum(self):
         page_text = ''
 
-        self.log_login_attempt()
 
         page_request = self.session.post('https://forums.somethingawful.com/account.php',
                                          data={'action': 'login', 'username': settings.VF_SA_USER,

--- a/votefinder/main/SAForumPageDownloader.py
+++ b/votefinder/main/SAForumPageDownloader.py
@@ -79,8 +79,3 @@ class SAForumPageDownloader():
         inputs.pop('preview')
 
         self.session.post(post_url, data=inputs)
-
-
-if __name__ == '__main__':
-    dl = SAForumPageDownloader()
-    result = dl.download('https://forums.somethingawful.com/showthread.php?threadid=3552086')  # noqa: WPS110

--- a/votefinder/main/views.py
+++ b/votefinder/main/views.py
@@ -941,10 +941,13 @@ def votecount_to_image(img, game, xpos=0, ypos=0, max_width=600):
     draw = ImageDraw.Draw(img)
     regular_font = ImageFont.truetype(settings.VF_REGULAR_FONT_PATH, 15)
     bold_font = ImageFont.truetype(settings.VF_BOLD_FONT_PATH, 15)
-    tid = 11  # default template, no custom image template support yet
-    game.template = VotecountTemplate.objects.get(id=tid)
+
+    # Reset game template to None to force use of the system default votecount template instead of whatever the game is actually set to
+    game.template = None
+
     vc = VotecountFormatter.VotecountFormatter(game)
     vc.go(show_comment=False)
+
     split_vc = re.compile(r'\[.*?\]').sub('', vc.bbcode_votecount).split('\r\n')
     header_text = split_vc[0]  # Explicitly take the first and last elements in case of multiline templates
     footer_text = split_vc[-1]

--- a/votefinder/settings.py
+++ b/votefinder/settings.py
@@ -145,15 +145,22 @@ if VF_LOG_FILE_PATH is not None and VF_LOG_LEVEL is not None:
                 'level': VF_LOG_LEVEL,
                 'class': 'logging.FileHandler',
                 'filename': VF_LOG_FILE_PATH,
+                'formatter': 'simple'
             },
         },
         'loggers': {
-            'django': {
+            '': {
                 'handlers': ['file'],
                 'level': VF_LOG_LEVEL,
                 'propagate': True,
             },
         },
+        'formatters': {
+            'simple': {
+                'format': '{name} {levelname} {asctime} {message}',
+                'style': '{',
+            },
+        }
     }
 
 PASSWORD_HASHERS = [


### PR DESCRIPTION
Cleans up hardcoded features that prevent votefinder from running with a clean database:
- excises the log to hardcoded game 228 when logging into Something Awful and replaces it with a normal info log
- enable logging for non-django sources to enable the above
- excises votecount image generation using hardcoded votecount template 11; now uses the system default instead, as appears to have been intended
- cleaned up some unused test code in the SA downloader