### PR TITLE
basic support for running with a sqlite3 database instead of mysql

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,12 +5,21 @@
 # Enables debug mode. You probably want this to be set to true in local development, but not in live deployment.
 VF_DEBUG=true
 
-# Tells Votefinder how to connect to the database. Insert your database credentials here.
+# The following settings tell Votefinder how to connect to the database. You can choose between using MySQL or SQLite.
+# If you are setting up locally and don't already have a database you want to use, selecting SQLite is probably easiest,
+# as it should work out of the box with no additional dependencies.
+
+# Uncomment to use SQLite.
+# VF_DATABASE_DRIVER=sqlite
+# VF_SQLITE_FILENAME=votefinder.sqlite3
+
+# Uncomment and insert your database credentials here to use MySQL.
 # You can also specify VF_MYSQL_PORT if you want to connect to a non-default port.
-VF_MYSQL_HOST=localhost
-VF_MYSQL_USER=username
-VF_MYSQL_PASS=password
-VF_MYSQL_NAME=database
+# VF_DATABASE_DRIVER=mysql
+# VF_MYSQL_HOST=
+# VF_MYSQL_USER=
+# VF_MYSQL_PASS=
+# VF_MYSQL_NAME=
 
 # Uncomment and specify a file path to enable logging. Valid log levels are DEBUG, INFO, WARNING, ERROR and CRITICAL.
 # VF_LOG_LEVEL=DEBUG

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 *.pyc
+*.sqlite*
 .idea/
 .vscode/

--- a/votefinder/settings.py
+++ b/votefinder/settings.py
@@ -7,6 +7,8 @@
 # configuration required by Django and sensible defaults for other settings. Any secrets should be in
 # the dotenv file, or else in the operating system's environment.
 
+from django.core.exceptions import ImproperlyConfigured
+
 # env_helpers is a helper module for accessing the environment.
 from .env_helpers import env_bool, env_string, env_integer, env_string_list
 
@@ -30,6 +32,12 @@ VF_LOG_LEVEL = env_string('VF_LOG_LEVEL')
 VF_LOG_FILE_PATH = env_string('VF_LOG_FILE_PATH')
 
 # Database settings
+VF_DATABASE_DRIVER = env_string('VF_DATABASE_DRIVER', 'mysql')
+
+# Used when database driver is sqlite
+VF_SQLITE_FILENAME = env_string('VF_SQLITE_FILENAME')
+
+# Used when database driver is mysql
 VF_MYSQL_NAME = env_string('VF_MYSQL_NAME')
 VF_MYSQL_USER = env_string('VF_MYSQL_USER')
 VF_MYSQL_PASS = env_string('VF_MYSQL_PASS')
@@ -100,8 +108,10 @@ EMAIL_HOST_PASSWORD = VF_EMAIL_PASS
 EMAIL_USE_TLS = VF_EMAIL_USE_TLS
 DEFAULT_FROM_EMAIL = VF_FROM_EMAIL
 
-DATABASES = {
-    'default': {
+DATABASES = {}
+
+if VF_DATABASE_DRIVER == 'mysql':
+    DATABASES['default'] = {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': VF_MYSQL_NAME,
         'USER': VF_MYSQL_USER,
@@ -109,8 +119,14 @@ DATABASES = {
         'HOST': VF_MYSQL_HOST,
         'PORT': VF_MYSQL_PORT,
         'OPTIONS': {'charset': 'utf8mb4'},
-    },
-}
+    }
+elif VF_DATABASE_DRIVER == 'sqlite':
+    DATABASES['default'] = {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': VF_SQLITE_FILENAME
+    }
+else:
+    raise ImproperlyConfigured('VF_DATABASE_DRIVER must be set to one of: mysql, sqlite')
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Adds support for using sqlite3 instead of mysql, primarily to make it easier to run votefinder locally without needing to have a mysql server running.