### PR TITLE
Votecount image bbcode

### DIFF
--- a/votefinder/main/templates/game.html
+++ b/votefinder/main/templates/game.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load access_settings %}
 {% block title %}{{ game.name|safe }}{% endblock %}
 
 {% block script %}
@@ -48,7 +49,7 @@ $(document).ready(function () {
     });
 
     $('#voteImgButton').click(function () {
-        prompt("Copy and paste the following BBCode to make an auto-updating votecount image:", "[url=https://votefinder.org{{ game.get_absolute_url }}#votecount][img]https://votefinder.org/img/{{ game.slug }}[/img][/url]");
+        prompt("Copy and paste the following BBCode to make an auto-updating votecount image:", "[url=https://{% access_settings "VF_PRIMARY_DOMAIN" %}{{ game.get_absolute_url }}#votecount][img]https://{% access_settings "VF_PRIMARY_DOMAIN" %}/img/{{ game.slug }}[/img][/url]");
     });
     $('.button').button();
     $('#refreshbutton').button();

--- a/votefinder/main/templatetags/access_settings.py
+++ b/votefinder/main/templatetags/access_settings.py
@@ -1,0 +1,8 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+@register.simple_tag
+def get_settings_value(setting):
+    return getattr(settings, setting, "")

--- a/votefinder/main/templatetags/access_settings.py
+++ b/votefinder/main/templatetags/access_settings.py
@@ -4,5 +4,5 @@ from django.conf import settings
 register = template.Library()
 
 @register.simple_tag
-def get_settings_value(setting):
+def access_settings(setting):
     return getattr(settings, setting, "")


### PR DESCRIPTION
Just a quick update to fix an issue I discovered testing locally - the button to generate some BBCode used `votefinder.org` as the domain, even if running locally, on the beta server, etc.

This involves adding a teensy little custom template tag that will get a specific setting from `settings.py` when needed - right now it's just being used here, but I have a feeling there's a few more places we'll want that kind of functionality.

There are also some other template tags that we might create in the future if we notice some repetition in templates, or some front-end JS stuff we might be able to get rid of with a judicious template tag - it'll live there, too.