### PR TITLE
3.6 dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,7 @@ VF_DEBUG=false
 # VF_MYSQL_USER=
 # VF_MYSQL_PASS=
 # VF_MYSQL_NAME=
+# VF_MYSQL_PORT=
 
 # Uncomment and specify a file path to enable logging. Valid log levels are DEBUG, INFO, WARNING, ERROR and CRITICAL.
 # VF_LOG_LEVEL=DEBUG

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .vscode/
 guni.log
 Pipfile
+Pipfile.lock
 /vfvenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.9.1
-Django>=3.0.12
+Django==4.2.13
 html5lib>=1.0.1
 mysqlclient>=1.4.6
 parsedatetime==2.6

--- a/votefinder/main/VotecountFormatter.py
+++ b/votefinder/main/VotecountFormatter.py
@@ -89,20 +89,24 @@ class VotecountFormatter:
         votecount = ""
         template_single_line = Template(self.game_template.single_line + "\n")
         for x in self.game_state['votecounts_by_player']:
-            votelist = []
-            for vote in x['votes']:
-                if vote['unvote'] == True:
-                    votelist.append(f"[s]{vote['author']}[/s]")
-                elif vote['enabled'] == True:
-                    votelist.append(f"[url={vote['url']}]{vote['author']}[/url]")
-                else:
-                    votelist.append(f"{vote['author']}")
+            if len(x['votes']) > 0:
+                votelist = []
+                for vote in x['votes']:
+                    if vote['unvote'] == True:
+                        votelist.append(f"[s]{vote['author']}[/s]")
+                    elif vote['enabled'] == True:
+                        votelist.append(f"[url={vote['url']}]{vote['author']}[/url]")
+                    else:
+                        votelist.append(f"{vote['author']}")
 
-            votelist_string = ', '.join(votelist)
+                votelist_string = ', '.join(votelist)
 
-            ticks = (f"[img]{self.game_template.empty_tick}[/img]" * (self.to_execute - x['votes_received'])) + f"[img]{self.game_template.full_tick}[/img]" * x['votes_received']
+                # temporarily removing reference to tickmark images for consistency
+                # would like to rework template system to make these user-selectable but
+                # that's part of a larger votecount template rewrite
+                ticks = (f"⚪" * (self.to_execute - x['votes_received'])) + f"🟢" * x['votes_received']
 
-            votecount += template_single_line.render(context = Context({'ticks': ticks,'target': x['player_name'], 'count': x['votes_received'], 'votelist': votelist_string}))
+                votecount += template_single_line.render(context = Context({'ticks': ticks,'target': x['player_name'], 'count': x['votes_received'], 'votelist': votelist_string}))
 
         # Figure out deadline
         if self.game_state['deadline'] == '':

--- a/votefinder/main/templates/game.html
+++ b/votefinder/main/templates/game.html
@@ -43,6 +43,11 @@ var maxPages = {{ game.max_pages }};
 var pushed = false;
 $(document).ready(function () {
 
+    /* Something about how django renders the bbcode template is very resistant
+     to being marked as safe - this is a bodge to make things output appropriately
+     until templates can just be fully reworked */
+    $('#bbcode')[0].innerHTML = $('#bbcode')[0].innerHTML.replaceAll('amp;', '');
+
     $('#dialog').modal('hide');
     $('#liveThread').button();
     $('#updateButton').button().click(function () {
@@ -744,7 +749,7 @@ $(document).ready(function () {
                         <div id="votecount-results">{% votecount_html vc %}</div>
                     </div>
                     <div class="col-md-3">
-                        <textarea id="bbcode" class="form-control">{{ bbcode_votecount }}</textarea>
+                        <textarea id="bbcode" class="form-control">{{ bbcode_votecount|safe|escape }}</textarea>
                     </div>
                 </div>
             </div></div>


### PR DESCRIPTION
Slight updates to how bbcode is generated - something about template rendering changed, and attempting to use `&` in the template ends up getting overwritten with `&amp;` no matter what combination of escaping on/off/safe-ing the template output works. The horrible quick fix is to just do a find-and-replace in JS in `game.html` for now.

The way templates are managed desperately needs a rewrite, but this is a patch on it for now.